### PR TITLE
Added pt-PT locale.

### DIFF
--- a/config/locales/contact_us.pt-PT.yml
+++ b/config/locales/contact_us.pt-PT.yml
@@ -1,0 +1,25 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+pt-PT:
+  contact_us:
+    contact_mailer:
+      contact_email:
+        sent_by_contact_form: "Enviado pelo formulário de contacto. %{email}"
+        sent_by_name: "Enviado por %{name} de %{email}"
+        subject: "Contacte-nos: nova mensagem de %{email}"
+    contacts:
+      new: &new
+        contact_us: "Contacte-nos"
+        email: "Email"
+        message: "Mensagem"
+        name: "Nome"
+        subject: "Assunto"
+        submit: "Enviar"
+      new_formtastic:
+        <<: *new
+      new_simple_form:
+        <<: *new
+    notices:
+      error: "Tem de preencher ambos os campos."
+      success: "Email de contacto foi enviado com sucesso."


### PR DESCRIPTION
Hello,

Please note that this adds the pt-PT locale according to the ortographic rules pre-2010.
The [new ortographic agreement](http://en.wikipedia.org/wiki/Portuguese_Language_Orthographic_Agreement_of_1990), was adopted in Portugal in 2010 and states that for example Contact should be `contato` instead of `contacto`. However, many people contest it and still use the old rules, it's a complicated matter.

For the purpose of this gem, the `pt_BR` locale is correct towards the new ortographic agreement, so I opted to submit `pt-PT` according to the old rules, as most people still use it.

Would you rather I'd submit according to the new rules?
