### PR TITLE
change to rspec expectations syntax

### DIFF
--- a/spec/features/contact_us_lint_spec.rb
+++ b/spec/features/contact_us_lint_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Contact Us page' do
+describe 'Contact Us page', :type => :feature do
 
   after do
     ActionMailer::Base.deliveries = []
@@ -18,11 +18,11 @@ describe 'Contact Us page' do
   it 'displays default contact form properly' do
     visit contact_us_path
     within "form#new_contact_us_contact" do
-      page.should have_selector "input#contact_us_contact_email"
-      page.should have_selector "textarea#contact_us_contact_message"
-      page.should_not have_selector "input#contact_us_contact_name"
-      page.should_not have_selector "input#contact_us_contact_subject"
-      page.should have_selector "input.submit"
+      expect(page).to have_selector "input#contact_us_contact_email"
+      expect(page).to have_selector "textarea#contact_us_contact_message"
+      expect(page).not_to have_selector "input#contact_us_contact_name"
+      expect(page).not_to have_selector "input#contact_us_contact_subject"
+      expect(page).to have_selector "input.submit"
     end
   end
 
@@ -40,18 +40,18 @@ describe 'Contact Us page' do
       end
 
       it "I should be redirected to the homepage" do
-        current_path.should == "/"
+        expect(current_path).to eq("/")
       end
 
       it "An email should have been sent" do
-        ActionMailer::Base.deliveries.size.should == 1
+        expect(ActionMailer::Base.deliveries.size).to eq(1)
       end
 
       it "The email should have the correct attributes" do
         mail = ActionMailer::Base.deliveries.last
-        mail.to.should == ['test@test.com']
-        mail.from.should == ['test@example.com']
-        mail.body.should match 'howdy'
+        expect(mail.to).to eq(['test@test.com'])
+        expect(mail.from).to eq(['test@example.com'])
+        expect(mail.body).to match 'howdy'
       end
     end
 
@@ -65,15 +65,15 @@ describe 'Contact Us page' do
 
         it "I should see two error messages" do
           within '#contact_us_contact_email_input' do
-            page.should have_content "is invalid"
+            expect(page).to have_content "is invalid"
           end
           within '#contact_us_contact_message_input' do
-            page.should have_content "can't be blank"
+            expect(page).to have_content "can't be blank"
           end
         end
 
         it "An email should not have been sent" do
-          ActionMailer::Base.deliveries.size.should == 0
+          expect(ActionMailer::Base.deliveries.size).to eq(0)
         end
       end
     end
@@ -88,8 +88,8 @@ describe 'Contact Us page' do
     end
 
     it "displays an input for name and subject" do
-      page.should have_selector "input#contact_us_contact_name"
-      page.should have_selector "input#contact_us_contact_subject"
+      expect(page).to have_selector "input#contact_us_contact_name"
+      expect(page).to have_selector "input#contact_us_contact_subject"
     end
 
     context "Submitting the form" do
@@ -103,20 +103,20 @@ describe 'Contact Us page' do
         end
 
         it "I should be redirected to the homepage" do
-          current_path.should == "/"
+          expect(current_path).to eq("/")
         end
 
         it "An email should have been sent" do
-          ActionMailer::Base.deliveries.size.should == 1
+          expect(ActionMailer::Base.deliveries.size).to eq(1)
         end
 
         it "The email should have the correct attributes" do
           mail = ActionMailer::Base.deliveries.last
-          mail.body.should match 'howdy'
-          mail.body.should match 'Jeff'
-          mail.from.should == ['test@example.com']
-          mail.subject.should match 'Testing contact form.'
-          mail.to.should == ['test@test.com']
+          expect(mail.body).to match 'howdy'
+          expect(mail.body).to match 'Jeff'
+          expect(mail.from).to eq(['test@example.com'])
+          expect(mail.subject).to match 'Testing contact form.'
+          expect(mail.to).to eq(['test@test.com'])
         end
       end
 
@@ -127,15 +127,15 @@ describe 'Contact Us page' do
 
         it "I should see error messages" do
           within '#contact_us_contact_name_input' do
-            page.should have_content "can't be blank"
+            expect(page).to have_content "can't be blank"
           end
           within '#contact_us_contact_subject_input' do
-            page.should have_content "can't be blank"
+            expect(page).to have_content "can't be blank"
           end
         end
 
         it "An email should not have been sent" do
-          ActionMailer::Base.deliveries.size.should == 0
+          expect(ActionMailer::Base.deliveries.size).to eq(0)
         end
       end
     end


### PR DESCRIPTION
RSpec 3 users will get a deprecation notice about the `should` syntax. I've changed this over
