### PR TITLE
Added the optional locale scope to the config/routes.rb file. Added a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ config.require_subject = true
 To redirect to a specific URL after a successful form submission:
 ```ruby
 config.success_redirect = '/contact-success'
+```
 
 If you're using I18n localization and would like to have the locale be a part of your paths 
 For example: /en/contact-us OR /fr/contact-us OR /en-UK/contact-us
+```ruby
 config.localize_routes = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ config.require_subject = true
 To redirect to a specific URL after a successful form submission:
 ```ruby
 config.success_redirect = '/contact-success'
+
+If you're using I18n localization and would like to have the locale be a part of your paths 
+For example: /en/contact-us OR /fr/contact-us OR /en-UK/contact-us
+config.localize_routes = true
 ```
 
 ### Views
@@ -85,6 +89,9 @@ bundle exec rake contact_us:copy_locales
 ```
 
 Please feel free to submit your own locales so that other users will hopefully find this gem more useful in your language.
+
+If you would like to include the locale in your paths (e.g. /en/contact-us), set the localize_routes
+parameter to true in your initializer (see the configuration section above)
 
 ### Formtastic
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   # Place the contact_us routes within the optional locale scope
-  # If the I18n gem is installed and the localize_routes variable has 
+  # If the I18n gem is installed and the localize_routes variable has
   # been set to true in the application's initializer file
   if defined?(I18n) && ContactUs.localize_routes
     scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-
   # Place the contact_us routes within the optional locale scope
   # If the I18n gem is installed and the localize_routes variable has
   # been set to true in the application's initializer file

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,17 @@
 Rails.application.routes.draw do
-  resources :contacts,
-    :controller => 'contact_us/contacts',
-    :only       => [:new, :create]
-  get 'contact-us' => 'contact_us/contacts#new', :as => :contact_us
+  # If the I18n gem is installed then place the contact_us routes within the optional locale scope
+  if defined?(I18n) and ContactUs.localize_routes
+    scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
+      resources :contacts,
+                :controller => 'contact_us/contacts',
+                :only       => [:new, :create]
+      get 'contact-us' => 'contact_us/contacts#new', :as => :contact_us
+    end
+    
+  else
+    resources :contacts,
+              :controller => 'contact_us/contacts',
+              :only       => [:new, :create]
+    get 'contact-us' => 'contact_us/contacts#new', :as => :contact_us
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,22 @@
 Rails.application.routes.draw do
-  # If the I18n gem is installed then place the contact_us routes within the optional locale scope
-  if defined?(I18n) and ContactUs.localize_routes
+
+  # Place the contact_us routes within the optional locale scope
+  # If the I18n gem is installed and the localize_routes variable has 
+  # been set to true in the application's initializer file
+  if defined?(I18n) && ContactUs.localize_routes
     scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
       resources :contacts,
-                :controller => 'contact_us/contacts',
-                :only       => [:new, :create]
-      get 'contact-us' => 'contact_us/contacts#new', :as => :contact_us
+                controller: "contact_us/contacts",
+                only:       [:new, :create]
+                
+      get "contact-us": "contact_us/contacts#new", as: :contact_us
     end
     
   else
     resources :contacts,
-              :controller => 'contact_us/contacts',
-              :only       => [:new, :create]
-    get 'contact-us' => 'contact_us/contacts#new', :as => :contact_us
+              controller: "contact_us/contacts",
+              only:       [:new, :create]
+              
+    get "contact-us": "contact_us/contacts#new", as: :contact_us
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,15 +8,15 @@ Rails.application.routes.draw do
       resources :contacts,
                 controller: "contact_us/contacts",
                 only:       [:new, :create]
-                
+
       get "contact-us" => "contact_us/contacts#new", as: :contact_us
     end
-    
+
   else
     resources :contacts,
               controller: "contact_us/contacts",
               only:       [:new, :create]
-              
+
     get "contact-us" => "contact_us/contacts#new", as: :contact_us
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
                 controller: "contact_us/contacts",
                 only:       [:new, :create]
                 
-      get "contact-us": "contact_us/contacts#new", as: :contact_us
+      get "contact-us" => "contact_us/contacts#new", as: :contact_us
     end
     
   else
@@ -17,6 +17,6 @@ Rails.application.routes.draw do
               controller: "contact_us/contacts",
               only:       [:new, :create]
               
-    get "contact-us": "contact_us/contacts#new", as: :contact_us
+    get "contact-us" => "contact_us/contacts#new", as: :contact_us
   end
 end

--- a/lib/contact_us.rb
+++ b/lib/contact_us.rb
@@ -23,6 +23,9 @@ module ContactUs
   mattr_accessor :parent_mailer
   @@parent_mailer = "ActionMailer::Base"
 
+  # allows for a locale to appear in the path (e.g. /fr/contact-us OR /en/contact-us)
+  mattr_accessor :localize_routes
+
   # Default way to setup ContactUs. Run rake contact_us:install to create
   # a fresh initializer with all configuration values.
   def self.setup

--- a/lib/contact_us.rb
+++ b/lib/contact_us.rb
@@ -23,7 +23,7 @@ module ContactUs
   mattr_accessor :parent_mailer
   @@parent_mailer = "ActionMailer::Base"
 
-  # allows for a locale to appear in the path 
+  # allows for a locale to appear in the path
   #   (e.g. /fr/contact-us OR /en/contact-us)
   mattr_accessor :localize_routes
 

--- a/lib/contact_us.rb
+++ b/lib/contact_us.rb
@@ -23,7 +23,8 @@ module ContactUs
   mattr_accessor :parent_mailer
   @@parent_mailer = "ActionMailer::Base"
 
-  # allows for a locale to appear in the path (e.g. /fr/contact-us OR /en/contact-us)
+  # allows for a locale to appear in the path 
+  #   (e.g. /fr/contact-us OR /en/contact-us)
   mattr_accessor :localize_routes
 
   # Default way to setup ContactUs. Run rake contact_us:install to create

--- a/lib/contact_us/version.rb
+++ b/lib/contact_us/version.rb
@@ -1,3 +1,3 @@
 module ContactUs
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
… configuration variable called localize_routes that users can enable (disabled by default). This should prevent conflicts with any installations using a parent path that is not a locale (e.g. /blog/contact-us). Also updated the README to inform the users about the new option and incremented the version number.
